### PR TITLE
Add MySQL integration tests and account lifecycle management

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,4 +26,4 @@ jobs:
           cache: maven
 
       - name: Verify application
-        run: ./mvnw --batch-mode --no-transfer-progress clean verify
+        run: ./mvnw --batch-mode --no-transfer-progress clean verify -Pintegration-tests

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,21 @@
 			<artifactId>h2</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-testcontainers</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>mysql</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -124,5 +139,27 @@
 			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<profile>
+			<id>integration-tests</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-failsafe-plugin</artifactId>
+						<executions>
+							<execution>
+								<goals>
+									<goal>integration-test</goal>
+									<goal>verify</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 
 </project>

--- a/src/main/java/com/adriangniadek/BankingSystem/controller/AccountController.java
+++ b/src/main/java/com/adriangniadek/BankingSystem/controller/AccountController.java
@@ -5,6 +5,7 @@ import com.adriangniadek.BankingSystem.dto.AccountEntryDTO;
 import com.adriangniadek.BankingSystem.dto.AccountStatementDTO;
 import com.adriangniadek.BankingSystem.dto.CreateAccountRequest;
 import com.adriangniadek.BankingSystem.dto.CreateDepositRequest;
+import com.adriangniadek.BankingSystem.dto.UpdateAccountStatusRequest;
 import com.adriangniadek.BankingSystem.service.AccountService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
@@ -86,6 +87,20 @@ public class AccountController {
         
         AccountStatementDTO statement = accountService.generateAccountStatement(accountId, startDate, endDate);
         return ResponseEntity.ok(statement);
+    }
+
+    @PatchMapping("/{accountId}/status")
+    public ResponseEntity<AccountDTO> updateAccountStatus(
+            @PathVariable @Positive(message = "Account ID must be positive") Long accountId,
+            @RequestBody @Valid UpdateAccountStatusRequest request) {
+        return ResponseEntity.ok(accountService.updateAccountStatus(accountId, request));
+    }
+
+    @DeleteMapping("/{accountId}")
+    public ResponseEntity<Void> closeAccount(
+            @PathVariable @Positive(message = "Account ID must be positive") Long accountId) {
+        accountService.closeAccount(accountId);
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/src/main/java/com/adriangniadek/BankingSystem/dto/AccountDTO.java
+++ b/src/main/java/com/adriangniadek/BankingSystem/dto/AccountDTO.java
@@ -1,5 +1,6 @@
 package com.adriangniadek.BankingSystem.dto;
 
+import com.adriangniadek.BankingSystem.enums.AccountStatus;
 import com.adriangniadek.BankingSystem.enums.AccountType;
 
 import java.math.BigDecimal;
@@ -9,5 +10,6 @@ public record AccountDTO(Long id,
                          AccountType accountType,
                          BigDecimal balance,
                          String currency,
+                         AccountStatus status,
                          Long userId) {
 }

--- a/src/main/java/com/adriangniadek/BankingSystem/dto/UpdateAccountStatusRequest.java
+++ b/src/main/java/com/adriangniadek/BankingSystem/dto/UpdateAccountStatusRequest.java
@@ -1,0 +1,9 @@
+package com.adriangniadek.BankingSystem.dto;
+
+import com.adriangniadek.BankingSystem.enums.AccountStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateAccountStatusRequest(
+        @NotNull(message = "Account status is required")
+        AccountStatus status) {
+}

--- a/src/main/java/com/adriangniadek/BankingSystem/enums/AccountStatus.java
+++ b/src/main/java/com/adriangniadek/BankingSystem/enums/AccountStatus.java
@@ -1,0 +1,7 @@
+package com.adriangniadek.BankingSystem.enums;
+
+public enum AccountStatus {
+    ACTIVE,
+    BLOCKED,
+    CLOSED
+}

--- a/src/main/java/com/adriangniadek/BankingSystem/mapper/AccountMapper.java
+++ b/src/main/java/com/adriangniadek/BankingSystem/mapper/AccountMapper.java
@@ -14,6 +14,7 @@ public class AccountMapper {
                 account.getAccountType(),
                 account.getBalance(),
                 account.getCurrency(),
+                account.getStatus(),
                 account.getUser().getId()
         );
     }

--- a/src/main/java/com/adriangniadek/BankingSystem/model/Account.java
+++ b/src/main/java/com/adriangniadek/BankingSystem/model/Account.java
@@ -1,6 +1,7 @@
 package com.adriangniadek.BankingSystem.model;
 
 import com.adriangniadek.BankingSystem.enums.AccountType;
+import com.adriangniadek.BankingSystem.enums.AccountStatus;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -30,6 +31,10 @@ public class Account {
 
     @Column(nullable = false, length = 3)
     private String currency;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private AccountStatus status = AccountStatus.ACTIVE;
 
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)

--- a/src/main/java/com/adriangniadek/BankingSystem/service/AccountService.java
+++ b/src/main/java/com/adriangniadek/BankingSystem/service/AccountService.java
@@ -5,6 +5,7 @@ import com.adriangniadek.BankingSystem.dto.AccountEntryDTO;
 import com.adriangniadek.BankingSystem.dto.AccountStatementDTO;
 import com.adriangniadek.BankingSystem.dto.CreateAccountRequest;
 import com.adriangniadek.BankingSystem.dto.CreateDepositRequest;
+import com.adriangniadek.BankingSystem.dto.UpdateAccountStatusRequest;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -18,4 +19,6 @@ public interface AccountService {
     BigDecimal getAccountBalance(Long accountId);
     AccountDTO getAccountById(Long accountId);
     AccountStatementDTO generateAccountStatement(Long accountId, LocalDateTime startDate, LocalDateTime endDate);
+    AccountDTO updateAccountStatus(Long accountId, UpdateAccountStatusRequest request);
+    void closeAccount(Long accountId);
 }

--- a/src/main/java/com/adriangniadek/BankingSystem/service/impl/AccountServiceImpl.java
+++ b/src/main/java/com/adriangniadek/BankingSystem/service/impl/AccountServiceImpl.java
@@ -5,7 +5,9 @@ import com.adriangniadek.BankingSystem.dto.AccountEntryDTO;
 import com.adriangniadek.BankingSystem.dto.AccountStatementDTO;
 import com.adriangniadek.BankingSystem.dto.CreateAccountRequest;
 import com.adriangniadek.BankingSystem.dto.CreateDepositRequest;
+import com.adriangniadek.BankingSystem.dto.UpdateAccountStatusRequest;
 import com.adriangniadek.BankingSystem.enums.AccountEntryType;
+import com.adriangniadek.BankingSystem.enums.AccountStatus;
 import com.adriangniadek.BankingSystem.exception.BusinessRuleViolationException;
 import com.adriangniadek.BankingSystem.exception.ResourceConflictException;
 import com.adriangniadek.BankingSystem.exception.ResourceNotFoundException;
@@ -80,6 +82,8 @@ public class AccountServiceImpl implements AccountService {
             validateRepeatedDeposit(existingEntry, accountId, request);
             return accountEntryMapper.toDto(existingEntry);
         }
+
+        requireActiveAccount(account, "Deposits require an active account");
 
         if (!account.getCurrency().equals(request.currency())) {
             throw new BusinessRuleViolationException("Deposit currency must match account currency");
@@ -164,6 +168,43 @@ public class AccountServiceImpl implements AccountService {
         );
     }
 
+    @Override
+    @Transactional
+    @PreAuthorize("hasRole('ADMIN')")
+    public AccountDTO updateAccountStatus(Long accountId, UpdateAccountStatusRequest request) {
+        Account account = accountRepository.findByIdForUpdate(accountId)
+                .orElseThrow(() -> new ResourceNotFoundException("Account not found"));
+
+        if (request.status() == AccountStatus.CLOSED) {
+            throw new BusinessRuleViolationException(
+                    "Closed status can only be set by closing the account");
+        }
+        if (account.getStatus() == AccountStatus.CLOSED) {
+            throw new BusinessRuleViolationException("Closed account status cannot be changed");
+        }
+
+        account.setStatus(request.status());
+        return accountMapper.toDto(account);
+    }
+
+    @Override
+    @Transactional
+    @PreAuthorize("hasRole('ADMIN') or @bankingAuthorization.canAccessAccount(#accountId, authentication)")
+    public void closeAccount(Long accountId) {
+        Account account = accountRepository.findByIdForUpdate(accountId)
+                .orElseThrow(() -> new ResourceNotFoundException("Account not found"));
+
+        if (account.getStatus() == AccountStatus.CLOSED) {
+            return;
+        }
+        if (account.getBalance().compareTo(BigDecimal.ZERO) != 0) {
+            throw new BusinessRuleViolationException(
+                    "Account balance must be zero before closing");
+        }
+
+        account.setStatus(AccountStatus.CLOSED);
+    }
+
     private String generateUniqueAccountNumber() {
         String accountNumber;
         do {
@@ -178,6 +219,7 @@ public class AccountServiceImpl implements AccountService {
         account.setAccountType(request.accountType());
         account.setBalance(BigDecimal.ZERO.setScale(2));
         account.setCurrency(request.currency());
+        account.setStatus(AccountStatus.ACTIVE);
         account.setUser(user);
 
         return accountMapper.toDto(accountRepository.save(account));
@@ -203,6 +245,12 @@ public class AccountServiceImpl implements AccountService {
                 && entry.getDescription().equals(request.description());
         if (!sameRequest) {
             throw new ResourceConflictException("Idempotency key was already used for another operation");
+        }
+    }
+
+    private void requireActiveAccount(Account account, String message) {
+        if (account.getStatus() != AccountStatus.ACTIVE) {
+            throw new BusinessRuleViolationException(message);
         }
     }
 

--- a/src/main/java/com/adriangniadek/BankingSystem/service/impl/TransferServiceImpl.java
+++ b/src/main/java/com/adriangniadek/BankingSystem/service/impl/TransferServiceImpl.java
@@ -4,6 +4,7 @@ import com.adriangniadek.BankingSystem.dto.CreateTransferRequest;
 import com.adriangniadek.BankingSystem.dto.PageResponse;
 import com.adriangniadek.BankingSystem.dto.TransferDTO;
 import com.adriangniadek.BankingSystem.enums.AccountEntryType;
+import com.adriangniadek.BankingSystem.enums.AccountStatus;
 import com.adriangniadek.BankingSystem.enums.TransferStatus;
 import com.adriangniadek.BankingSystem.exception.BusinessRuleViolationException;
 import com.adriangniadek.BankingSystem.exception.ResourceConflictException;
@@ -113,6 +114,12 @@ public class TransferServiceImpl implements TransferService {
 
     private void validateAccounts(
             Account sourceAccount, Account targetAccount, CreateTransferRequest request) {
+        if (sourceAccount.getStatus() != AccountStatus.ACTIVE) {
+            throw new BusinessRuleViolationException("Source account must be active");
+        }
+        if (targetAccount.getStatus() != AccountStatus.ACTIVE) {
+            throw new BusinessRuleViolationException("Target account must be active");
+        }
         if (!sourceAccount.getCurrency().equals(request.currency())
                 || !targetAccount.getCurrency().equals(request.currency())) {
             throw new BusinessRuleViolationException(

--- a/src/main/resources/db/migration/V3__add_account_status.sql
+++ b/src/main/resources/db/migration/V3__add_account_status.sql
@@ -1,0 +1,6 @@
+ALTER TABLE accounts
+    ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE';
+
+ALTER TABLE accounts
+    ADD CONSTRAINT chk_accounts_status
+        CHECK (status IN ('ACTIVE', 'BLOCKED', 'CLOSED'));

--- a/src/test/java/com/adriangniadek/BankingSystem/controller/AccountControllerTest.java
+++ b/src/test/java/com/adriangniadek/BankingSystem/controller/AccountControllerTest.java
@@ -5,6 +5,7 @@ import com.adriangniadek.BankingSystem.dto.AccountEntryDTO;
 import com.adriangniadek.BankingSystem.dto.CreateAccountRequest;
 import com.adriangniadek.BankingSystem.dto.CreateDepositRequest;
 import com.adriangniadek.BankingSystem.enums.AccountEntryType;
+import com.adriangniadek.BankingSystem.enums.AccountStatus;
 import com.adriangniadek.BankingSystem.enums.AccountType;
 import com.adriangniadek.BankingSystem.exception.ResourceNotFoundException;
 import com.adriangniadek.BankingSystem.security.JwtAuthFilter;
@@ -55,7 +56,8 @@ class AccountControllerTest {
     void shouldCreateAccountForCurrentUser() throws Exception {
         CreateAccountRequest request = new CreateAccountRequest(AccountType.CHECKING, "PLN");
         AccountDTO account = new AccountDTO(
-                1L, "12345678901234567890", AccountType.CHECKING, BigDecimal.ZERO, "PLN", 1L);
+                1L, "12345678901234567890", AccountType.CHECKING,
+                BigDecimal.ZERO, "PLN", AccountStatus.ACTIVE, 1L);
         Mockito.when(accountService.createCurrentUserAccount(eq(EMAIL), any(CreateAccountRequest.class)))
                 .thenReturn(account);
 
@@ -72,7 +74,7 @@ class AccountControllerTest {
         Mockito.when(accountService.getCurrentUserAccounts(EMAIL)).thenReturn(List.of(
                 new AccountDTO(
                         1L, "12345678901234567890", AccountType.CHECKING,
-                        BigDecimal.ZERO, "PLN", 1L)));
+                        BigDecimal.ZERO, "PLN", AccountStatus.ACTIVE, 1L)));
 
         mockMvc.perform(get("/accounts/me").principal(AUTHENTICATION))
                 .andExpect(status().isOk())
@@ -107,7 +109,8 @@ class AccountControllerTest {
     void shouldCreateAccount() throws Exception {
         CreateAccountRequest request = new CreateAccountRequest(AccountType.SAVINGS, "PLN");
         AccountDTO dto = new AccountDTO(
-                1L, "12345678901234567890", AccountType.SAVINGS, BigDecimal.ZERO, "PLN", 1L);
+                1L, "12345678901234567890", AccountType.SAVINGS,
+                BigDecimal.ZERO, "PLN", AccountStatus.ACTIVE, 1L);
         Mockito.when(accountService.createAccount(eq(1L), any(CreateAccountRequest.class))).thenReturn(dto);
 
         mockMvc.perform(post("/accounts/1")
@@ -120,8 +123,10 @@ class AccountControllerTest {
     @Test
     void shouldReturnUserAccounts() throws Exception {
         List<AccountDTO> accounts = List.of(
-                new AccountDTO(1L, "PL111", AccountType.SAVINGS, BigDecimal.valueOf(1000), "PLN", 1L),
-                new AccountDTO(2L, "PL222", AccountType.CHECKING, BigDecimal.valueOf(500), "PLN", 1L)
+                new AccountDTO(1L, "PL111", AccountType.SAVINGS,
+                        BigDecimal.valueOf(1000), "PLN", AccountStatus.ACTIVE, 1L),
+                new AccountDTO(2L, "PL222", AccountType.CHECKING,
+                        BigDecimal.valueOf(500), "PLN", AccountStatus.BLOCKED, 1L)
         );
 
         Mockito.when(accountService.getUserAccounts(1L)).thenReturn(accounts);
@@ -130,6 +135,37 @@ class AccountControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$", hasSize(2)))
                 .andExpect(jsonPath("$[0].accountNumber").value("PL111"));
+    }
+
+    @Test
+    void shouldUpdateAccountStatus() throws Exception {
+        AccountDTO blockedAccount = new AccountDTO(
+                1L, "12345678901234567890", AccountType.CHECKING,
+                BigDecimal.ZERO, "PLN", AccountStatus.BLOCKED, 1L);
+        Mockito.when(accountService.updateAccountStatus(eq(1L), any())).thenReturn(blockedAccount);
+
+        mockMvc.perform(patch("/accounts/1/status")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"status\":\"BLOCKED\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("BLOCKED"));
+    }
+
+    @Test
+    void shouldCloseAccount() throws Exception {
+        mockMvc.perform(delete("/accounts/1"))
+                .andExpect(status().isNoContent());
+
+        Mockito.verify(accountService).closeAccount(1L);
+    }
+
+    @Test
+    void shouldRejectMissingAccountStatus() throws Exception {
+        mockMvc.perform(patch("/accounts/1/status")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors.status").value("Account status is required"));
     }
 
     @Test

--- a/src/test/java/com/adriangniadek/BankingSystem/integration/MySqlBankingIT.java
+++ b/src/test/java/com/adriangniadek/BankingSystem/integration/MySqlBankingIT.java
@@ -1,0 +1,210 @@
+package com.adriangniadek.BankingSystem.integration;
+
+import com.adriangniadek.BankingSystem.dto.CreateTransferRequest;
+import com.adriangniadek.BankingSystem.enums.AccountType;
+import com.adriangniadek.BankingSystem.exception.BusinessRuleViolationException;
+import com.adriangniadek.BankingSystem.model.Account;
+import com.adriangniadek.BankingSystem.model.User;
+import com.adriangniadek.BankingSystem.repository.AccountEntryRepository;
+import com.adriangniadek.BankingSystem.repository.AccountRepository;
+import com.adriangniadek.BankingSystem.repository.TransferRepository;
+import com.adriangniadek.BankingSystem.repository.UserRepository;
+import com.adriangniadek.BankingSystem.service.TransferService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+@SpringBootTest
+@ActiveProfiles("test")
+class MySqlBankingIT {
+
+    @Container
+    @ServiceConnection
+    static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0.36");
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private AccountRepository accountRepository;
+
+    @Autowired
+    private TransferRepository transferRepository;
+
+    @Autowired
+    private AccountEntryRepository accountEntryRepository;
+
+    @Autowired
+    private TransferService transferService;
+
+    @BeforeEach
+    void cleanBusinessData() {
+        accountEntryRepository.deleteAllInBatch();
+        transferRepository.deleteAllInBatch();
+        accountRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+    }
+
+    @Test
+    void shouldApplyAllFlywayMigrationsToMySql() throws SQLException {
+        try (Connection connection = jdbcTemplate.getDataSource().getConnection()) {
+            assertThat(connection.getMetaData().getDatabaseProductName()).isEqualTo("MySQL");
+        }
+
+        List<String> versions = jdbcTemplate.queryForList(
+                "SELECT version FROM flyway_schema_history WHERE success = 1 ORDER BY installed_rank",
+                String.class);
+        Integer roleCount = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM roles", Integer.class);
+        Integer ledgerTableCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM information_schema.tables "
+                        + "WHERE table_schema = DATABASE() AND table_name = 'account_entries'",
+                Integer.class);
+
+        assertThat(versions).containsExactly("1", "2");
+        assertThat(roleCount).isEqualTo(2);
+        assertThat(ledgerTableCount).isEqualTo(1);
+    }
+
+    @RepeatedTest(5)
+    void shouldPreventNegativeBalanceDuringConcurrentTransfers() throws Exception {
+        User owner = userRepository.saveAndFlush(user());
+        Account source = accountRepository.saveAndFlush(account(owner, "10000000000000000001", "100.00"));
+        Account firstTarget = accountRepository.saveAndFlush(account(owner, "10000000000000000002", "0.00"));
+        Account secondTarget = accountRepository.saveAndFlush(account(owner, "10000000000000000003", "0.00"));
+
+        CreateTransferRequest firstRequest = transferRequest(source.getId(), firstTarget.getId());
+        CreateTransferRequest secondRequest = transferRequest(source.getId(), secondTarget.getId());
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        try {
+            Future<TransferAttempt> first = executor.submit(
+                    () -> executeTransferAsAdmin(firstRequest, ready, start));
+            Future<TransferAttempt> second = executor.submit(
+                    () -> executeTransferAsAdmin(secondRequest, ready, start));
+
+            assertThat(ready.await(10, TimeUnit.SECONDS)).isTrue();
+            start.countDown();
+
+            List<TransferAttempt> attempts = List.of(
+                    first.get(15, TimeUnit.SECONDS),
+                    second.get(15, TimeUnit.SECONDS));
+
+            assertThat(attempts).filteredOn(TransferAttempt::successful).hasSize(1);
+            assertThat(attempts).filteredOn(attempt -> !attempt.successful()).singleElement()
+                    .satisfies(attempt -> assertThat(attempt.failure())
+                            .isInstanceOf(BusinessRuleViolationException.class)
+                            .hasMessage("Insufficient funds in source account"));
+        } finally {
+            start.countDown();
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
+        }
+
+        Account updatedSource = accountRepository.findById(source.getId()).orElseThrow();
+        Account updatedFirstTarget = accountRepository.findById(firstTarget.getId()).orElseThrow();
+        Account updatedSecondTarget = accountRepository.findById(secondTarget.getId()).orElseThrow();
+
+        assertThat(updatedSource.getBalance()).isEqualByComparingTo("20.00");
+        assertThat(updatedFirstTarget.getBalance().add(updatedSecondTarget.getBalance()))
+                .isEqualByComparingTo("80.00");
+        assertThat(transferRepository.count()).isEqualTo(1);
+        assertThat(accountEntryRepository.count()).isEqualTo(2);
+    }
+
+    private TransferAttempt executeTransferAsAdmin(
+            CreateTransferRequest request,
+            CountDownLatch ready,
+            CountDownLatch start) throws InterruptedException {
+        SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+        securityContext.setAuthentication(new UsernamePasswordAuthenticationToken(
+                "integration-admin@example.com",
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_ADMIN"))));
+        SecurityContextHolder.setContext(securityContext);
+        ready.countDown();
+
+        try {
+            if (!start.await(10, TimeUnit.SECONDS)) {
+                return TransferAttempt.failed(new IllegalStateException("Concurrent transfer start timed out"));
+            }
+            transferService.createTransfer(request, "integration-admin@example.com");
+            return TransferAttempt.succeeded();
+        } catch (RuntimeException exception) {
+            return TransferAttempt.failed(exception);
+        } finally {
+            SecurityContextHolder.clearContext();
+        }
+    }
+
+    private User user() {
+        User user = new User();
+        user.setFirstName("Integration");
+        user.setLastName("Owner");
+        user.setEmail("integration-owner@example.com");
+        user.setPassword("encoded-password");
+        user.setPhoneNumber("123456789");
+        user.setPesel("12345678901");
+        return user;
+    }
+
+    private Account account(User owner, String number, String balance) {
+        Account account = new Account();
+        account.setAccountNumber(number);
+        account.setAccountType(AccountType.CHECKING);
+        account.setBalance(new BigDecimal(balance));
+        account.setCurrency("PLN");
+        account.setUser(owner);
+        return account;
+    }
+
+    private CreateTransferRequest transferRequest(Long sourceAccountId, Long targetAccountId) {
+        return new CreateTransferRequest(
+                UUID.randomUUID(),
+                sourceAccountId,
+                targetAccountId,
+                new BigDecimal("80.00"),
+                "PLN",
+                "Concurrent integration transfer");
+    }
+
+    private record TransferAttempt(boolean successful, RuntimeException failure) {
+        static TransferAttempt succeeded() {
+            return new TransferAttempt(true, null);
+        }
+
+        static TransferAttempt failed(RuntimeException failure) {
+            return new TransferAttempt(false, failure);
+        }
+    }
+}

--- a/src/test/java/com/adriangniadek/BankingSystem/integration/MySqlBankingIT.java
+++ b/src/test/java/com/adriangniadek/BankingSystem/integration/MySqlBankingIT.java
@@ -1,6 +1,7 @@
 package com.adriangniadek.BankingSystem.integration;
 
 import com.adriangniadek.BankingSystem.dto.CreateTransferRequest;
+import com.adriangniadek.BankingSystem.enums.AccountStatus;
 import com.adriangniadek.BankingSystem.enums.AccountType;
 import com.adriangniadek.BankingSystem.exception.BusinessRuleViolationException;
 import com.adriangniadek.BankingSystem.model.Account;
@@ -9,6 +10,7 @@ import com.adriangniadek.BankingSystem.repository.AccountEntryRepository;
 import com.adriangniadek.BankingSystem.repository.AccountRepository;
 import com.adriangniadek.BankingSystem.repository.TransferRepository;
 import com.adriangniadek.BankingSystem.repository.UserRepository;
+import com.adriangniadek.BankingSystem.service.AccountService;
 import com.adriangniadek.BankingSystem.service.TransferService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.RepeatedTest;
@@ -66,6 +68,9 @@ class MySqlBankingIT {
     @Autowired
     private TransferService transferService;
 
+    @Autowired
+    private AccountService accountService;
+
     @BeforeEach
     void cleanBusinessData() {
         accountEntryRepository.deleteAllInBatch();
@@ -89,7 +94,7 @@ class MySqlBankingIT {
                         + "WHERE table_schema = DATABASE() AND table_name = 'account_entries'",
                 Integer.class);
 
-        assertThat(versions).containsExactly("1", "2");
+        assertThat(versions).containsExactly("1", "2", "3");
         assertThat(roleCount).isEqualTo(2);
         assertThat(ledgerTableCount).isEqualTo(1);
     }
@@ -108,19 +113,19 @@ class MySqlBankingIT {
         ExecutorService executor = Executors.newFixedThreadPool(2);
 
         try {
-            Future<TransferAttempt> first = executor.submit(
+            Future<OperationAttempt> first = executor.submit(
                     () -> executeTransferAsAdmin(firstRequest, ready, start));
-            Future<TransferAttempt> second = executor.submit(
+            Future<OperationAttempt> second = executor.submit(
                     () -> executeTransferAsAdmin(secondRequest, ready, start));
 
             assertThat(ready.await(10, TimeUnit.SECONDS)).isTrue();
             start.countDown();
 
-            List<TransferAttempt> attempts = List.of(
+            List<OperationAttempt> attempts = List.of(
                     first.get(15, TimeUnit.SECONDS),
                     second.get(15, TimeUnit.SECONDS));
 
-            assertThat(attempts).filteredOn(TransferAttempt::successful).hasSize(1);
+            assertThat(attempts).filteredOn(OperationAttempt::successful).hasSize(1);
             assertThat(attempts).filteredOn(attempt -> !attempt.successful()).singleElement()
                     .satisfies(attempt -> assertThat(attempt.failure())
                             .isInstanceOf(BusinessRuleViolationException.class)
@@ -142,8 +147,84 @@ class MySqlBankingIT {
         assertThat(accountEntryRepository.count()).isEqualTo(2);
     }
 
-    private TransferAttempt executeTransferAsAdmin(
+    @RepeatedTest(5)
+    void shouldKeepClosedAccountEmptyWhenClosureRacesWithIncomingTransfer() throws Exception {
+        User owner = userRepository.saveAndFlush(user());
+        Account closingAccount = accountRepository.saveAndFlush(
+                account(owner, "20000000000000000001", "0.00"));
+        Account fundingAccount = accountRepository.saveAndFlush(
+                account(owner, "20000000000000000002", "100.00"));
+        CreateTransferRequest request = new CreateTransferRequest(
+                UUID.randomUUID(),
+                fundingAccount.getId(),
+                closingAccount.getId(),
+                new BigDecimal("10.00"),
+                "PLN",
+                "Concurrent closure transfer");
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        try {
+            Future<OperationAttempt> transfer = executor.submit(
+                    () -> executeAsAdmin(
+                            () -> transferService.createTransfer(
+                                    request, "integration-admin@example.com"),
+                            ready,
+                            start));
+            Future<OperationAttempt> closure = executor.submit(
+                    () -> executeAsAdmin(
+                            () -> accountService.closeAccount(closingAccount.getId()),
+                            ready,
+                            start));
+
+            assertThat(ready.await(10, TimeUnit.SECONDS)).isTrue();
+            start.countDown();
+
+            List<OperationAttempt> attempts = List.of(
+                    transfer.get(15, TimeUnit.SECONDS),
+                    closure.get(15, TimeUnit.SECONDS));
+
+            assertThat(attempts).filteredOn(OperationAttempt::successful).hasSize(1);
+            assertThat(attempts).filteredOn(attempt -> !attempt.successful()).singleElement()
+                    .satisfies(attempt -> {
+                        assertThat(attempt.failure())
+                                .isInstanceOf(BusinessRuleViolationException.class);
+                        assertThat(attempt.failure().getMessage()).isIn(
+                                "Target account must be active",
+                                "Account balance must be zero before closing");
+                    });
+        } finally {
+            start.countDown();
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
+        }
+
+        Account updatedAccount = accountRepository.findById(closingAccount.getId()).orElseThrow();
+        if (updatedAccount.getStatus() == AccountStatus.CLOSED) {
+            assertThat(updatedAccount.getBalance()).isEqualByComparingTo("0.00");
+            assertThat(transferRepository.count()).isZero();
+            assertThat(accountEntryRepository.count()).isZero();
+        } else {
+            assertThat(updatedAccount.getStatus()).isEqualTo(AccountStatus.ACTIVE);
+            assertThat(updatedAccount.getBalance()).isEqualByComparingTo("10.00");
+            assertThat(transferRepository.count()).isOne();
+            assertThat(accountEntryRepository.count()).isEqualTo(2);
+        }
+    }
+
+    private OperationAttempt executeTransferAsAdmin(
             CreateTransferRequest request,
+            CountDownLatch ready,
+            CountDownLatch start) throws InterruptedException {
+        return executeAsAdmin(
+                () -> transferService.createTransfer(request, "integration-admin@example.com"),
+                ready,
+                start);
+    }
+
+    private OperationAttempt executeAsAdmin(
+            Runnable operation,
             CountDownLatch ready,
             CountDownLatch start) throws InterruptedException {
         SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
@@ -156,12 +237,13 @@ class MySqlBankingIT {
 
         try {
             if (!start.await(10, TimeUnit.SECONDS)) {
-                return TransferAttempt.failed(new IllegalStateException("Concurrent transfer start timed out"));
+                return OperationAttempt.failed(
+                        new IllegalStateException("Concurrent operation start timed out"));
             }
-            transferService.createTransfer(request, "integration-admin@example.com");
-            return TransferAttempt.succeeded();
+            operation.run();
+            return OperationAttempt.succeeded();
         } catch (RuntimeException exception) {
-            return TransferAttempt.failed(exception);
+            return OperationAttempt.failed(exception);
         } finally {
             SecurityContextHolder.clearContext();
         }
@@ -198,13 +280,13 @@ class MySqlBankingIT {
                 "Concurrent integration transfer");
     }
 
-    private record TransferAttempt(boolean successful, RuntimeException failure) {
-        static TransferAttempt succeeded() {
-            return new TransferAttempt(true, null);
+    private record OperationAttempt(boolean successful, RuntimeException failure) {
+        static OperationAttempt succeeded() {
+            return new OperationAttempt(true, null);
         }
 
-        static TransferAttempt failed(RuntimeException failure) {
-            return new TransferAttempt(false, failure);
+        static OperationAttempt failed(RuntimeException failure) {
+            return new OperationAttempt(false, failure);
         }
     }
 }

--- a/src/test/java/com/adriangniadek/BankingSystem/security/AccountAccessSecurityTest.java
+++ b/src/test/java/com/adriangniadek/BankingSystem/security/AccountAccessSecurityTest.java
@@ -1,5 +1,6 @@
 package com.adriangniadek.BankingSystem.security;
 
+import com.adriangniadek.BankingSystem.enums.AccountStatus;
 import com.adriangniadek.BankingSystem.enums.AccountType;
 import com.adriangniadek.BankingSystem.enums.RoleType;
 import com.adriangniadek.BankingSystem.model.Account;
@@ -27,6 +28,8 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -265,6 +268,57 @@ class AccountAccessSecurityTest {
         assertThat(accountEntryRepository.count()).isZero();
     }
 
+    @Test
+    @WithMockUser(username = "admin@example.com", roles = "ADMIN")
+    void shouldAllowAdministratorToBlockAccount() throws Exception {
+        mockMvc.perform(patch("/accounts/{accountId}/status", ownerAccount.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"status\":\"BLOCKED\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("BLOCKED"));
+
+        assertThat(accountRepository.findById(ownerAccount.getId()).orElseThrow().getStatus())
+                .isEqualTo(AccountStatus.BLOCKED);
+    }
+
+    @Test
+    @WithMockUser(username = "owner@example.com", roles = "USER")
+    void shouldRejectUserAccountStatusUpdate() throws Exception {
+        mockMvc.perform(patch("/accounts/{accountId}/status", ownerAccount.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"status\":\"BLOCKED\"}"))
+                .andExpect(status().isForbidden());
+
+        assertThat(accountRepository.findById(ownerAccount.getId()).orElseThrow().getStatus())
+                .isEqualTo(AccountStatus.ACTIVE);
+    }
+
+    @Test
+    @WithMockUser(username = "owner@example.com", roles = "USER")
+    void shouldAllowOwnerToCloseEmptyAccount() throws Exception {
+        ownerAccount.setBalance(BigDecimal.ZERO.setScale(2));
+        accountRepository.saveAndFlush(ownerAccount);
+
+        mockMvc.perform(delete("/accounts/{accountId}", ownerAccount.getId()))
+                .andExpect(status().isNoContent());
+
+        assertThat(accountRepository.findById(ownerAccount.getId()).orElseThrow().getStatus())
+                .isEqualTo(AccountStatus.CLOSED);
+    }
+
+    @Test
+    @WithMockUser(username = "owner@example.com", roles = "USER")
+    void shouldRejectClosingAnotherUsersAccount() throws Exception {
+        otherAccount.setBalance(BigDecimal.ZERO.setScale(2));
+        accountRepository.saveAndFlush(otherAccount);
+
+        mockMvc.perform(delete("/accounts/{accountId}", otherAccount.getId()))
+                .andExpect(status().isForbidden());
+
+        assertThat(accountRepository.findById(otherAccount.getId()).orElseThrow().getStatus())
+                .isEqualTo(AccountStatus.ACTIVE);
+    }
+
     private User user(String email, String pesel, String phoneNumber, Role role) {
         User user = new User();
         user.setFirstName("Test");
@@ -283,6 +337,7 @@ class AccountAccessSecurityTest {
         account.setAccountType(AccountType.CHECKING);
         account.setBalance(new BigDecimal("100.00"));
         account.setCurrency("PLN");
+        account.setStatus(AccountStatus.ACTIVE);
         account.setUser(owner);
         return account;
     }

--- a/src/test/java/com/adriangniadek/BankingSystem/service/impl/AccountServiceImplTest.java
+++ b/src/test/java/com/adriangniadek/BankingSystem/service/impl/AccountServiceImplTest.java
@@ -5,8 +5,11 @@ import com.adriangniadek.BankingSystem.dto.AccountEntryDTO;
 import com.adriangniadek.BankingSystem.dto.AccountStatementDTO;
 import com.adriangniadek.BankingSystem.dto.CreateAccountRequest;
 import com.adriangniadek.BankingSystem.dto.CreateDepositRequest;
+import com.adriangniadek.BankingSystem.dto.UpdateAccountStatusRequest;
 import com.adriangniadek.BankingSystem.enums.AccountEntryType;
+import com.adriangniadek.BankingSystem.enums.AccountStatus;
 import com.adriangniadek.BankingSystem.enums.AccountType;
+import com.adriangniadek.BankingSystem.exception.BusinessRuleViolationException;
 import com.adriangniadek.BankingSystem.exception.ResourceNotFoundException;
 import com.adriangniadek.BankingSystem.mapper.AccountEntryMapper;
 import com.adriangniadek.BankingSystem.mapper.AccountMapper;
@@ -78,6 +81,7 @@ class AccountServiceImplTest {
         testAccount.setAccountType(AccountType.SAVINGS);
         testAccount.setBalance(new BigDecimal("1000.00"));
         testAccount.setCurrency("USD");
+        testAccount.setStatus(AccountStatus.ACTIVE);
         testAccount.setUser(testUser);
     }
 
@@ -98,6 +102,7 @@ class AccountServiceImplTest {
         assertThat(createdAccount.accountNumber()).isEqualTo("12345678901234567890");
         assertThat(createdAccount.accountType()).isEqualTo(AccountType.SAVINGS);
         assertThat(createdAccount.balance()).isEqualByComparingTo("0.00");
+        assertThat(createdAccount.status()).isEqualTo(AccountStatus.ACTIVE);
 
         ArgumentCaptor<Account> accountCaptor = ArgumentCaptor.forClass(Account.class);
         verify(accountRepository).save(accountCaptor.capture());
@@ -225,6 +230,73 @@ class AccountServiceImplTest {
 
         assertThat(testAccount.getBalance()).isEqualByComparingTo("1000.00");
         verify(accountEntryRepository, never()).save(any());
+    }
+
+    @Test
+    void shouldRejectDepositToBlockedAccount() {
+        testAccount.setStatus(AccountStatus.BLOCKED);
+        CreateDepositRequest request = new CreateDepositRequest(
+                UUID.randomUUID(), new BigDecimal("250.00"), "USD", "Cash deposit");
+        when(accountRepository.findByIdForUpdate(testAccount.getId())).thenReturn(Optional.of(testAccount));
+
+        assertThatThrownBy(() -> accountService.deposit(
+                testAccount.getId(), request, "admin@example.com"))
+                .isInstanceOf(BusinessRuleViolationException.class)
+                .hasMessage("Deposits require an active account");
+
+        verify(accountEntryRepository, never()).save(any());
+    }
+
+    @Test
+    void shouldBlockActiveAccount() {
+        when(accountRepository.findByIdForUpdate(testAccount.getId())).thenReturn(Optional.of(testAccount));
+
+        AccountDTO result = accountService.updateAccountStatus(
+                testAccount.getId(), new UpdateAccountStatusRequest(AccountStatus.BLOCKED));
+
+        assertThat(result.status()).isEqualTo(AccountStatus.BLOCKED);
+        assertThat(testAccount.getStatus()).isEqualTo(AccountStatus.BLOCKED);
+    }
+
+    @Test
+    void shouldRejectClosedStatusInAdministrativeUpdate() {
+        when(accountRepository.findByIdForUpdate(testAccount.getId())).thenReturn(Optional.of(testAccount));
+
+        assertThatThrownBy(() -> accountService.updateAccountStatus(
+                testAccount.getId(), new UpdateAccountStatusRequest(AccountStatus.CLOSED)))
+                .isInstanceOf(BusinessRuleViolationException.class)
+                .hasMessage("Closed status can only be set by closing the account");
+    }
+
+    @Test
+    void shouldRejectReopeningClosedAccount() {
+        testAccount.setStatus(AccountStatus.CLOSED);
+        when(accountRepository.findByIdForUpdate(testAccount.getId())).thenReturn(Optional.of(testAccount));
+
+        assertThatThrownBy(() -> accountService.updateAccountStatus(
+                testAccount.getId(), new UpdateAccountStatusRequest(AccountStatus.ACTIVE)))
+                .isInstanceOf(BusinessRuleViolationException.class)
+                .hasMessage("Closed account status cannot be changed");
+    }
+
+    @Test
+    void shouldCloseAccountWithZeroBalance() {
+        testAccount.setBalance(BigDecimal.ZERO.setScale(2));
+        when(accountRepository.findByIdForUpdate(testAccount.getId())).thenReturn(Optional.of(testAccount));
+
+        accountService.closeAccount(testAccount.getId());
+
+        assertThat(testAccount.getStatus()).isEqualTo(AccountStatus.CLOSED);
+    }
+
+    @Test
+    void shouldRejectClosingAccountWithRemainingBalance() {
+        when(accountRepository.findByIdForUpdate(testAccount.getId())).thenReturn(Optional.of(testAccount));
+
+        assertThatThrownBy(() -> accountService.closeAccount(testAccount.getId()))
+                .isInstanceOf(BusinessRuleViolationException.class)
+                .hasMessage("Account balance must be zero before closing");
+        assertThat(testAccount.getStatus()).isEqualTo(AccountStatus.ACTIVE);
     }
 
     @Test

--- a/src/test/java/com/adriangniadek/BankingSystem/service/impl/TransferServiceImplTest.java
+++ b/src/test/java/com/adriangniadek/BankingSystem/service/impl/TransferServiceImplTest.java
@@ -4,6 +4,7 @@ import com.adriangniadek.BankingSystem.dto.CreateTransferRequest;
 import com.adriangniadek.BankingSystem.dto.PageResponse;
 import com.adriangniadek.BankingSystem.dto.TransferDTO;
 import com.adriangniadek.BankingSystem.enums.AccountEntryType;
+import com.adriangniadek.BankingSystem.enums.AccountStatus;
 import com.adriangniadek.BankingSystem.enums.TransferStatus;
 import com.adriangniadek.BankingSystem.exception.BusinessRuleViolationException;
 import com.adriangniadek.BankingSystem.exception.ResourceConflictException;
@@ -160,6 +161,28 @@ class TransferServiceImplTest {
     }
 
     @Test
+    void shouldRejectTransferFromBlockedAccount() {
+        sourceAccount.setStatus(AccountStatus.BLOCKED);
+        CreateTransferRequest request = request(1L, 2L, "100.00", "PLN");
+        mockLockedAccounts();
+
+        assertThatThrownBy(() -> transferService.createTransfer(request, "owner@example.com"))
+                .isInstanceOf(BusinessRuleViolationException.class)
+                .hasMessage("Source account must be active");
+    }
+
+    @Test
+    void shouldRejectTransferToClosedAccount() {
+        targetAccount.setStatus(AccountStatus.CLOSED);
+        CreateTransferRequest request = request(1L, 2L, "100.00", "PLN");
+        mockLockedAccounts();
+
+        assertThatThrownBy(() -> transferService.createTransfer(request, "owner@example.com"))
+                .isInstanceOf(BusinessRuleViolationException.class)
+                .hasMessage("Target account must be active");
+    }
+
+    @Test
     void shouldRejectTransferToSameAccountBeforeLocking() {
         CreateTransferRequest request = request(1L, 1L, "100.00", "PLN");
 
@@ -197,6 +220,7 @@ class TransferServiceImplTest {
         account.setId(id);
         account.setBalance(new BigDecimal(balance));
         account.setCurrency(currency);
+        account.setStatus(AccountStatus.ACTIVE);
         return account;
     }
 


### PR DESCRIPTION
## Summary

- add Testcontainers-based MySQL integration and concurrency tests
- verify Flyway migrations against MySQL in CI
- introduce ACTIVE, BLOCKED, and CLOSED account states
- protect deposits, transfers, and account closure with business rules and database locks

## Why

The application needs production-like database verification and an explicit account lifecycle before further banking features are added.

## Verification

- 97 standard tests pass
- 11 MySQL integration test invocations pass
- GitHub Actions runs `clean verify -Pintegration-tests`